### PR TITLE
Fixed single nonunique-primarykey property cause build error on generated code.

### DIFF
--- a/src/MasterMemory.GeneratorCore/TableTemplate.tt
+++ b/src/MasterMemory.GeneratorCore/TableTemplate.tt
@@ -42,7 +42,11 @@ namespace <#= Namespace #>.Tables
                 var mid = (int)(((uint)hi + (uint)lo) >> 1);
                 var selected = data[mid].<#= item.Properties[0].Name #>;
                 var found = (selected < key) ? -1 : (selected > key) ? 1 : 0;
+<# if(item.IsNonUnique) { #>
+                if (found == 0) { return FindRangeBy<#= item.BuildMethodName() #>(lo, hi); }
+<# } else { #>
                 if (found == 0) { return data[mid]; }
+<# } #>
                 if (found < 0) { lo = mid + 1; }
                 else { hi = mid - 1; }
             }


### PR DESCRIPTION
```.cs
[MessagePackObject(true)]
[MemoryTable(nameof(TestMaster))]
public class TestMaster
{
    [PrimaryKey, NonUnique]
    public int TestID { get; set; }
    public int Value { get; set; }
}
```

Code generator output a following code now, but it will cause a build error.

```.cs
[System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
public RangeView<TestMaster> FindByTestID(int key)
{
    var lo = 0;
    var hi = data.Length - 1;
    while (lo <= hi)
    {
        var mid = (int)(((uint)hi + (uint)lo) >> 1);
        var selected = data[mid].StructureID;
        var found = (selected < key) ? -1 : (selected > key) ? 1 : 0;
        if (found == 0) { return data[mid]; } // Here, array is not allowed to cast to RangeView.
        if (found < 0) { lo = mid + 1; }
        else { hi = mid - 1; }
    }
    return default;
}
```