### PR TITLE
Fix for FindManyRangeCore returns invalid range Issue 57

### DIFF
--- a/src/MasterMemory/Internal/BinarySearch.cs
+++ b/src/MasterMemory/Internal/BinarySearch.cs
@@ -60,7 +60,6 @@ namespace MasterMemory.Internal
         {
             if (array.Length == 0) return -1;
 
-            var originalHi = hi;
             lo = lo - 1;
 
             while (hi - lo > 1)
@@ -83,14 +82,7 @@ namespace MasterMemory.Internal
                 }
             }
 
-            if (selectLower)
-            {
-                return (lo < 0) ? 0 : lo;
-            }
-            else
-            {
-                return (originalHi <= hi) ? originalHi - 1 : hi;
-            }
+            return selectLower ? lo : hi;
         }
 
         // default lo = 0, hi = array.Count
@@ -151,5 +143,78 @@ namespace MasterMemory.Internal
                 ? index
                 : -1;
         }
+
+
+        //... want the lowest index of  Key <= Value
+        //... returns 0 if key is <= all values in array
+        //... returns array.Length if key is > all values in array
+
+        public static int LowerBoundClosest<T, TKey>(T[] array, int lo, int hi, TKey key, Func<T, TKey> selector, IComparer<TKey> comparer)
+        {
+            while (lo < hi)
+            {
+                var mid = lo + ((hi - lo) >> 1);
+                var found = comparer.Compare(key, selector(array[mid]));
+
+                if (found <= 0)     //... Key is <= value at mid
+                {
+                    hi = mid;
+                }
+                else
+                {
+                    lo = mid + 1;   //... Notice that lo starts at zero and can only increase
+                }
+            }
+
+            var index = lo;         //... index will always be zero or greater
+
+            if ( array.Length <= index)
+            {
+               return array.Length;
+            }
+
+            // check final
+            return (comparer.Compare(key, selector(array[index])) <= 0)
+                ? index
+                : -1;
+        }
+
+ 
+        //... want the highest index of  Key >= Value
+        //... returns -1 if key is < than all values in array
+        //... returns array.Length - 1 if key is >= than all values in array
+
+        public static int UpperBoundClosest<T, TKey>(T[] array, int lo, int hi, TKey key, Func<T, TKey> selector, IComparer<TKey> comparer)
+        {
+            while (lo < hi)
+            {
+                var mid = lo + ((hi - lo) >> 1);
+                var found = comparer.Compare(key, selector(array[mid]));
+
+                if (found >= 0)     //... Key >= value at mid
+                {
+                    lo = mid + 1;   //... Note lo starts at zero and can only increase
+                }
+                else
+                {
+                    hi = mid;
+                }
+            }
+
+            var index = (lo == 0) ? 0 : lo - 1;   //... index will always be zero or greater
+
+            if ( index >= array.Length )
+            {
+               return array.Length;
+            }
+
+            // check final
+            return (comparer.Compare(key, selector(array[index])) >= 0)
+                ? index
+                : -1;
+        }
+
+
+
     }
 }

--- a/src/MasterMemory/RangeView.cs
+++ b/src/MasterMemory/RangeView.cs
@@ -6,7 +6,7 @@ namespace MasterMemory
 {
     public readonly struct RangeView<T> : IEnumerable<T>, IReadOnlyList<T>, IList<T>
     {
-        public static RangeView<T> Empty => default(RangeView<T>);
+        public static RangeView<T> Empty => new RangeView<T>( null, -1, -1, false ); 
 
         readonly T[] orderedData;
         readonly int left;
@@ -46,7 +46,7 @@ namespace MasterMemory
 
         public RangeView(T[] orderedData, int left, int right, bool ascendant)
         {
-            this.hasValue = (orderedData.Length != 0) && (left <= right); // same index is length = 1
+            this.hasValue = (orderedData != null ) && (orderedData.Length != 0) && (left <= right); // same index is length = 1            this.orderedData = orderedData;
             this.orderedData = orderedData;
             this.left = left;
             this.right = right;

--- a/src/MasterMemory/TableBase.cs
+++ b/src/MasterMemory/TableBase.cs
@@ -2,6 +2,7 @@
 using MasterMemory.Validation;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace MasterMemory
 {
@@ -133,6 +134,10 @@ namespace MasterMemory
         {
             var lo = BinarySearch.FindClosest(indexArray, 0, indexArray.Length, min, keySelector, comparer, false);
             var hi = BinarySearch.FindClosest(indexArray, 0, indexArray.Length, max, keySelector, comparer, true);
+
+            if ( lo == -1 ) lo = 0;
+            if ( hi == indexArray.Length ) hi -= 1;
+
             return new RangeView<TElement>(indexArray, lo, hi, ascendant);
         }
 
@@ -152,15 +157,37 @@ namespace MasterMemory
         static protected RangeView<TElement> FindManyClosestCore<TKey>(TElement[] indexArray, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, TKey key, bool selectLower)
         {
             var closest = BinarySearch.FindClosest(indexArray, 0, indexArray.Length, key, keySelector, comparer, selectLower);
-            if (closest == -1) return RangeView<TElement>.Empty;
+
+            if ((closest == -1) || ( closest >= indexArray.Length ))
+                return RangeView<TElement>.Empty;
 
             return FindManyCore(indexArray, keySelector, comparer, keySelector(indexArray[closest]));
         }
 
         static protected RangeView<TElement> FindManyRangeCore<TKey>(TElement[] indexArray, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, TKey min, TKey max, bool ascendant)
         {
-            var lo = FindManyClosestCore(indexArray, keySelector, comparer, min, false).FirstIndex;
-            var hi = FindManyClosestCore(indexArray, keySelector, comparer, max, true).LastIndex;
+            //... Empty set when min > max
+            //... Alternatively, could treat this as between and swap min and max.
+
+            if ( Comparer<TKey>.Default.Compare( min, max ) > 0 )
+               return RangeView<TElement>.Empty;
+
+            //... want lo to be the lowest  index of the values >= than min.
+            //... lo should be in the range [0,arraylength]
+
+            var lo = BinarySearch.LowerBoundClosest(indexArray, 0, indexArray.Length, min, keySelector, comparer );
+
+            //... want hi to be the highest index of the values <= than max
+            //... hi should be in the range [-1,arraylength-1]
+
+            var hi = BinarySearch.UpperBoundClosest(indexArray, 0, indexArray.Length, max, keySelector, comparer );
+
+            Debug.Assert( lo >= 0 );
+            Debug.Assert( hi < indexArray.Length );
+
+            if ( hi < lo )
+               return RangeView<TElement>.Empty;
+
             return new RangeView<TElement>(indexArray, lo, hi, ascendant);
         }
     }

--- a/tests/MasterMemory.Tests/BinarySearchTest.cs
+++ b/tests/MasterMemory.Tests/BinarySearchTest.cs
@@ -84,7 +84,8 @@ namespace MasterMemory.Tests
                 new { id = 5, bound = 1000 },
             };
 
-            BinarySearch.FindClosest(source, 0, source.Length, -100, x => x.bound, Comparer<int>.Default, true).Should().Be(0);
+            BinarySearch.FindClosest(source, 0, source.Length, -100, x => x.bound, Comparer<int>.Default, true).Should().Be(-1);
+//          BinarySearch.FindClosest(source, 0, source.Length, -100, x => x.bound, Comparer<int>.Default, true).Should().Be(0);
             BinarySearch.FindClosest(source, 0, source.Length, 0, x => x.bound, Comparer<int>.Default, true).Should().Be(0);
             BinarySearch.FindClosest(source, 0, source.Length, 10, x => x.bound, Comparer<int>.Default, true).Should().Be(0);
             BinarySearch.FindClosest(source, 0, source.Length, 50, x => x.bound, Comparer<int>.Default, true).Should().Be(0);
@@ -98,7 +99,9 @@ namespace MasterMemory.Tests
             source[BinarySearch.FindClosest(source, 0, source.Length, 1000, x => x.bound, Comparer<int>.Default, true)].id.Should().Be(5);
             source[BinarySearch.FindClosest(source, 0, source.Length, 1001, x => x.bound, Comparer<int>.Default, true)].id.Should().Be(5);
             source[BinarySearch.FindClosest(source, 0, source.Length, 10000, x => x.bound, Comparer<int>.Default, true)].id.Should().Be(5);
-            source[BinarySearch.FindClosest(source, 0, source.Length, 10000, x => x.bound, Comparer<int>.Default, false)].id.Should().Be(5);
+//          source[BinarySearch.FindClosest(source, 0, source.Length, 10000, x => x.bound, Comparer<int>.Default, false)].id.Should().Be(5);
+ 
+            BinarySearch.FindClosest(source, 0, source.Length, 10000, x => x.bound, Comparer<int>.Default, false).Should().Be(6);
         }
     }
 }

--- a/tests/MasterMemory.Tests/DatabaseTest.cs
+++ b/tests/MasterMemory.Tests/DatabaseTest.cs
@@ -65,6 +65,21 @@ namespace MasterMemory.Tests
             db.SampleTable.SortByAge.Select(x => x.Id).OrderBy(x => x).ToArray().Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         }
 
+         [Fact]
+        public void Ranges()
+        {
+            var builder = new DatabaseBuilder();
+            builder.Append(CreateData());
+
+            var bin = builder.Build();
+            var db = new MemoryDatabase(bin);
+
+            db.SampleTable.FindRangeByAge(2,2).Select(x=>x.Id).ToArray().Should().BeEquivalentTo( new int[] {} );     
+            db.SampleTable.FindRangeByAge(30,50).Select(x=>x.Id).ToArray().Should().BeEquivalentTo( new int[] { 7, 8 } );     
+            db.SampleTable.FindRangeByAge(100,100).Select(x=>x.Id).ToArray().Should().BeEquivalentTo( new int[] {} );     
+        }
+
+
         [Fact]
         public void EmptyAll()
         {

--- a/tests/MasterMemory.Tests/MemoryTest.cs
+++ b/tests/MasterMemory.Tests/MemoryTest.cs
@@ -96,7 +96,8 @@ namespace MasterMemory.Tests
                 // first
                 for (int i = 0; i < 9; i++)
                 {
-                    table.FindClosestByAge(i, selectLower: true).First.Age.Should().Be(9);
+                    table.FindClosestByAge(i, selectLower: true).Count.Should().Be(0);
+//                  table.FindClosestByAge(i, selectLower: true).First.Age.Should().Be(9);
                 }
 
                 var lastAge = 9;
@@ -111,9 +112,12 @@ namespace MasterMemory.Tests
                 }
 
                 // last
-                for (int i = 99; i < 120; i++)
+                table.FindClosestByAge(99, selectLower: false).First.Age.Should().Be(99);
+
+                for (int i = 100; i < 120; i++)
                 {
-                    table.FindClosestByAge(i, selectLower: true).First.Age.Should().Be(99);
+                    table.FindClosestByAge(i, selectLower: false).Count.Should().Be(0);
+//                  table.FindClosestByAge(i, selectLower: true).First.Age.Should().Be(99);
                 }
             }
             {
@@ -134,9 +138,11 @@ namespace MasterMemory.Tests
                 }
 
                 // last
-                for (int i = 99; i < 120; i++)
+                table.FindClosestByAge(99, selectLower: false).First.Age.Should().Be(99);
+
+                for (int i = 100; i < 120; i++)
                 {
-                    table.FindClosestByAge(i, selectLower: false).First.Age.Should().Be(99);
+                    table.FindClosestByAge(i, selectLower: false).Count.Should().Be(0);
                 }
             }
         }
@@ -153,7 +159,8 @@ namespace MasterMemory.Tests
             //new Sample { Id = 4, Age = 89, FirstName = "aaa", LastName = "tako" },
             //new Sample { Id = 9, Age = 99, FirstName = "aaa", LastName = "ika" },
 
-            table.FindClosestByFirstNameAndAge(("aaa", 10), true).First.Age.Should().Be(19);
+            table.FindClosestByFirstNameAndAge(("aaa", 10), true).Count.Should().Be(0);
+            table.FindClosestByFirstNameAndAge(("aaa", 10), false).First.Age.Should().Be(19);
             table.FindClosestByFirstNameAndAge(("aaa", 92), true).First.Age.Should().Be(89);
             table.FindClosestByFirstNameAndAge(("aaa", 120), true).First.Age.Should().Be(99);
             table.FindClosestByFirstNameAndAge(("aaa", 10), false).First.Age.Should().Be(19);


### PR DESCRIPTION
Hi,

This open source thing is new to me.  My apologies in advance if I'm not following the expected protocol.

I created issue number 57 on the main repo - outlining an issue I had with RangeView<T>.FindManyRangeCore returning an invalid range when the data is entirely outside the range given by min and max parameters.  

This pull request includes a proposed solution.  The solution does change the values from BinarySearch.FindClosest, the values outside the range [1, N] are now being checked outside the BinarySearch routine (see TableBase.FindManyClosestCore).  The definition of Empty also changed to take -1, -1 as the default zero left/right values resulted in a FirstIndex/LastIndex that pointed to a valid entry in the index array.

To reduce the number of binary search calls by  FindManyRangeCore, I added two new routines to BinarySearch: LowerBoundClosest and UpperBoundClosest.

I have also added some additional tests that cover the case.

Hope you can use the work.  I like this project very much.

Regards
Tim







