### PR TITLE
Specify StringComparer.Ordinal to sort namespaces.

### DIFF
--- a/src/MasterMemory.GeneratorCore/CodeGenerator.cs
+++ b/src/MasterMemory.GeneratorCore/CodeGenerator.cs
@@ -46,7 +46,7 @@ namespace MasterMemory.GeneratorCore
                     Directory.CreateDirectory(outputDirectory);
                 }
 
-                var usingStrings = string.Join(Environment.NewLine, list.SelectMany(x => x.UsingStrings).Distinct().OrderBy(x => x));
+                var usingStrings = string.Join(Environment.NewLine, list.SelectMany(x => x.UsingStrings).Distinct().OrderBy(x => x, StringComparer.Ordinal));
 
                 var builderTemplate = new DatabaseBuilderTemplate();
                 var databaseTemplate = new MemoryDatabaseTemplate();
@@ -146,7 +146,7 @@ namespace MasterMemory.GeneratorCore
                 .Concat(ns)
                 .Select(x => x.Trim(';') + ";")
                 .Distinct()
-                .OrderBy(x => x)
+                .OrderBy(x => x, StringComparer.Ordinal)
                 .ToArray();
 
             foreach (var classDecl in classDeclarations)


### PR DESCRIPTION
NET 5.0 and earlier, the character comparison results are different. To fix it, specify `StringComparer.Ordinal`.

![image](https://user-images.githubusercontent.com/9012/101607615-218ee000-3a48-11eb-84b4-3cc49d5c3dcc.png)

- see: https://docs.microsoft.com/en-us/dotnet/standard/globalization-localization/globalization-icu