### PR TITLE
fix: when using union, validation may not be executed

### DIFF
--- a/src/MasterMemory.Unity/Assets/Scripts/MasterMemory/MemoryDatabaseBase.cs
+++ b/src/MasterMemory.Unity/Assets/Scripts/MasterMemory/MemoryDatabaseBase.cs
@@ -71,11 +71,6 @@ namespace MasterMemory
                     var validator = new Validator<TElement>(database, item, result, onceCalled, pkName, pkSelector);
                     validatable.Validate(validator);
                 }
-                else
-                {
-                    // all elements is not validatable, return immediately.
-                    return;
-                }
             }
         }
     }

--- a/src/MasterMemory/MemoryDatabaseBase.cs
+++ b/src/MasterMemory/MemoryDatabaseBase.cs
@@ -71,11 +71,6 @@ namespace MasterMemory
                     var validator = new Validator<TElement>(database, item, result, onceCalled, pkName, pkSelector);
                     validatable.Validate(validator);
                 }
-                else
-                {
-                    // all elements is not validatable, return immediately.
-                    return;
-                }
             }
         }
     }


### PR DESCRIPTION
When a master is defined using union, validation may not be executed.

Example

```csharp
[MemoryTable("TestParameter")]
[Union(0, typeof(Test1))]
[Union(1, typeof(Test2))]
public abstract class TestParameter
{
    protected TestParameter(uint key)
    {
        Key = key;
    }

    [PrimaryKey] [Key(0)] public uint Key { get; }
}

[MessagePackObject]
public class Test1 : TestParameter, IValidatable<TestParameter>
{
    public Test1(uint key, int value) : base(key)
    {
        Value = value;
    }

    [Key(1)] public int Value { get; }

    public void Validate(IValidator<TestParameter> validator)
    {
        validator.Fail("Fail");
    }
}

[MessagePackObject]
public class Test2 : TestParameter
{
    public Test2(uint key, string value) : base(key)
    {
        Value = value;
    }

    [Key(1)] public string Value { get; }
}
```

If the order of the `table` is [Test2, Test1], the validation of Test1 will not be executed because it will return.

```
foreach (var item in table)
{
    if (item is IValidatable<TElement> validatable)
    {
        var validator = new Validator<TElement>(database, item, result, onceCalled, pkName, pkSelector);
        validatable.Validate(validator);
    }
    else
    {
        // all elements is not validatable, return immediately.
        return;
    }
}
```

---

In fact, this is not the essence of the problem.
I want to run `IValidatable<Test1>` and `IValidatable<Test2>`.
Do you have any plans to support master data using Union?