### PR TITLE
ci: change upload-artifact & download-artifact to Cysharp/Actions

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -62,7 +62,7 @@ jobs:
           directory: src/MasterMemory.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MasterMemory.${{ matrix.unity }}.unitypackage.zip
           path: ./src/MasterMemory.Unity/*.unitypackage

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -66,3 +66,4 @@ jobs:
         with:
           name: MasterMemory.${{ matrix.unity }}.unitypackage.zip
           path: ./src/MasterMemory.Unity/*.unitypackage
+          retention-days: 1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -38,7 +38,7 @@ jobs:
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build -p:Version=${{ inputs.tag }}
       - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget
           path: ./publish
@@ -86,7 +86,7 @@ jobs:
           directory: src/MasterMemory.Unity
 
       # Store artifacts.
-      - uses: actions/upload-artifact@v2
+      - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: MasterMemory.Unity.${{ inputs.tag }}.unitypackage
           path: ./src/MasterMemory.Unity/MasterMemory.Unity.${{ inputs.tag }}.unitypackage

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           name: nuget
           path: ./publish
+          retention-days: 1
 
   build-unity:
     needs: [update-packagejson]
@@ -90,6 +91,7 @@ jobs:
         with:
           name: MasterMemory.Unity.${{ inputs.tag }}.unitypackage
           path: ./src/MasterMemory.Unity/MasterMemory.Unity.${{ inputs.tag }}.unitypackage
+          retention-days: 1
 
   # release
   create-release:


### PR DESCRIPTION
## tl;dr;

To handle actions/upload-artifact & download-artifact version consistency, manage actions version via Central Maanged Cysharp/Actions.
